### PR TITLE
fix for probable bug concerning memory allocation of tree->costArray

### DIFF
--- a/greedier_BATLZ.c
+++ b/greedier_BATLZ.c
@@ -1247,7 +1247,7 @@ SUFFIX_TREE* ST_CreateTree(unsigned char* str, DBL_WORD length)
    }
    heap+=sizeof(SUFFIX_TREE);
    tree->inversePointers = malloc(sizeof(NODE *) * (length + 2));
-   tree->costArray = malloc(sizeof(unsigned short int) * (length + 2));
+   tree->costArray = malloc(sizeof(unsigned int) * (length + 2));
    tree->maxStrDepth = malloc(sizeof(unsigned int) * (length + 2));
 #ifdef PREFIXSUM
    tree->prefixSumCostArray = malloc(sizeof(unsigned int) * (length + 2));


### PR DESCRIPTION
sizeof(unsigned short int) is used in malloc for tree->costArray, which is defined as unsigned int.
https://github.com/fmasillo/BAT-LZ/blob/cc66dd2db7dda2da00831aefdec2cfe3be6cbebd/suffix_tree.h#L93

The former type is usually 16 bits, while the latter type is usually 32 bits.